### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/osnabrugge/b884e9fb-b3b4-4301-95eb-c9f81b050420/7e88003e-b457-41d1-87d3-9e9c0dd0ac51/_apis/work/boardbadge/853059b6-dc5a-46ec-b926-e89e62263ee1)](https://dev.azure.com/osnabrugge/b884e9fb-b3b4-4301-95eb-c9f81b050420/_boards/board/t/7e88003e-b457-41d1-87d3-9e9c0dd0ac51/Microsoft.RequirementCategory)
 # testboards


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3003](https://dev.azure.com/osnabrugge/b884e9fb-b3b4-4301-95eb-c9f81b050420/_workitems/edit/3003). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.